### PR TITLE
[#3] LLM 모델 라우팅 구현

### DIFF
--- a/scripts/measure_tokens.py
+++ b/scripts/measure_tokens.py
@@ -1,0 +1,143 @@
+"""uv run python scripts/measure_tokens.py"""
+
+from shopigent.llm.token_counter import TokenCounter
+
+SAMPLE_PRODUCT = {
+    "title": "노스페이스 눕시 다운 패딩 점퍼 남성 겨울 구스다운 NJ1DQ55A",
+    "brand": "노스페이스",
+    "price": 289000,
+    "delivery_fee": 0,
+    "category": "패딩/점퍼",
+    "review_count": 1842,
+    "review_avg_rating": 4.7,
+    "description": "구스다운 90% 충전재 사용. 방풍/방수 기능성 원단. 경량 압축 보관 가능.",
+    "specs": {"소재": "겉감 100% 나일론, 충전재 구스다운 90%", "색상": "블랙, 네이비"},
+}
+
+SAMPLE_USER_PREFERENCE = "선호 브랜드: 노스페이스. 예산: 20~40만원. 선호 기능: 방풍, 방수."
+
+
+def build_query_expander_messages(query: str) -> list[dict]:
+    return [
+        {
+            "role": "system",
+            "content": (
+                "당신은 쇼핑 검색 전문가입니다. "
+                "사용자의 검색어를 분석하여 관련 키워드를 확장해주세요. "
+                "결과는 JSON 배열로 반환하세요."
+            ),
+        },
+        {
+            "role": "user",
+            "content": f"검색어: {query}\n\n관련 키워드 5개를 생성해주세요.",
+        },
+    ]
+
+
+def build_product_analyzer_messages(product: dict, user_preference: str) -> list[dict]:
+    product_info = (
+        f"상품명: {product['title']}\n"
+        f"브랜드: {product['brand']}\n"
+        f"가격: {product['price']:,}원\n"
+        f"배송비: {product['delivery_fee']:,}원\n"
+        f"카테고리: {product['category']}\n"
+        f"리뷰 수: {product['review_count']:,}건\n"
+        f"평균 평점: {product['review_avg_rating']}\n"
+        f"설명: {product['description']}\n"
+        f"스펙: {product['specs']}\n"
+    )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "당신은 상품 품질 분석 전문가입니다. "
+                "상품 정보와 사용자 선호도를 비교하여 적합도를 0~200점으로 평가해주세요. "
+                "JSON으로 {score, reason} 형태로 반환하세요."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"## 사용자 선호도\n{user_preference}\n\n"
+                f"## 상품 정보\n{product_info}\n"
+                "위 상품의 취향 적합도를 평가해주세요."
+            ),
+        },
+    ]
+
+
+def build_report_generator_messages(top5_products: list[dict], query: str) -> list[dict]:
+    products_text = ""
+    for i, p in enumerate(top5_products, 1):
+        products_text += (
+            f"\n### {i}위: {p['title']}\n"
+            f"- 가격: {p['price']:,}원\n"
+            f"- 브랜드: {p['brand']}\n"
+            f"- 평점: {p['review_avg_rating']} ({p['review_count']:,}건)\n"
+            f"- 설명: {p['description']}\n"
+        )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "당신은 쇼핑 리포트 작성 전문가입니다. "
+                "Top 5 상품 분석 결과를 보기 좋은 HTML 리포트로 작성해주세요. "
+                "각 상품의 장단점, 추천 이유를 포함하세요."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"검색어: {query}\n\n"
+                f"## Top 5 상품 분석 결과\n{products_text}\n"
+                "위 상품들에 대한 상세 리포트를 HTML 형식으로 작성해주세요."
+            ),
+        },
+    ]
+
+
+def main():
+    counter = TokenCounter()
+
+    calls = [
+        ("QueryExpander", build_query_expander_messages("겨울 패딩")),
+        (
+            "ProductAnalyzer (1건)",
+            build_product_analyzer_messages(SAMPLE_PRODUCT, SAMPLE_USER_PREFERENCE),
+        ),
+        (
+            "ProductAnalyzer (20건 추정)",
+            build_product_analyzer_messages(SAMPLE_PRODUCT, SAMPLE_USER_PREFERENCE),
+        ),
+        (
+            "ReportGenerator (Top5)",
+            build_report_generator_messages([SAMPLE_PRODUCT] * 5, "겨울 패딩"),
+        ),
+    ]
+
+    print("=" * 65)
+    print(f"{'호출 지점':<25} {'입력 토큰':>10} {'20건 추정':>10} {'비고'}")
+    print("-" * 65)
+
+    for name, messages in calls:
+        result = counter.count_messages(messages)
+        if "20건" in name:
+            estimated = result.input_tokens * 20
+            print(f"  {'(20건 병렬 호출 시)':.<25} {estimated:>10,} {'':>10} 1건×20")
+        else:
+            print(f"  {name:<25} {result.input_tokens:>10,}")
+
+    print("-" * 65)
+
+    query_tokens = counter.count_messages(calls[0][1]).input_tokens
+    analyzer_tokens = counter.count_messages(calls[1][1]).input_tokens * 20
+    report_tokens = counter.count_messages(calls[3][1]).input_tokens
+    total = query_tokens + analyzer_tokens + report_tokens
+    print(f"  {'합계 (1회 검색 추정)':<25} {total:>10,}")
+    print("=" * 65)
+    print(f"\n기준 모델: {counter.model}")
+    print("※ output 토큰은 실제 LLM 응답에 따라 달라지므로 input만 측정")
+
+
+if __name__ == "__main__":
+    main()

--- a/shopigent/config.py
+++ b/shopigent/config.py
@@ -10,6 +10,10 @@ class Settings(BaseSettings):
     anthropic_api_key: str = ""
     openai_api_key: str = ""
     llm_monthly_budget_usd: float = 10.0
+    llm_analyzer_model: str = "ollama/qwen2.5:7b"
+    llm_report_model: str = "gemini/gemini-2.0-flash"
+    llm_query_model: str = "ollama/qwen2.5:7b"
+    ollama_base_url: str = "http://localhost:11434"
 
     # 네이버 쇼핑 API
     naver_client_id: str = ""

--- a/shopigent/llm/analyzer.py
+++ b/shopigent/llm/analyzer.py
@@ -1,0 +1,48 @@
+import logging
+from dataclasses import dataclass
+
+from shopigent.llm.prompts.analyzer_prompts import (
+    PRODUCT_ANALYZER_SYSTEM_PROMPT,
+    format_product_analyzer_user_prompt,
+)
+from shopigent.llm.provider import LLMProvider
+from shopigent.scraper.base import RawProduct
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SCORE = 100.0
+DEFAULT_ASSESSMENT = "분석 실패"
+SCORE_MIN = 0.0
+SCORE_MAX = 200.0
+
+
+@dataclass
+class AnalysisResult:
+    preference_fit_score: float
+    assessment: str
+
+
+class ProductAnalyzer:
+    def __init__(self, llm_provider: LLMProvider):
+        self._llm = llm_provider
+
+    async def analyze(self, product: RawProduct, user_preference_text: str) -> AnalysisResult:
+        messages = [
+            {"role": "system", "content": PRODUCT_ANALYZER_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": format_product_analyzer_user_prompt(product, user_preference_text),
+            },
+        ]
+        try:
+            data = await self._llm.complete_json(messages=messages)
+            score = float(data.get("preference_fit_score", DEFAULT_SCORE))
+            score = max(SCORE_MIN, min(SCORE_MAX, score))
+            assessment = str(data.get("assessment", DEFAULT_ASSESSMENT))
+            return AnalysisResult(preference_fit_score=score, assessment=assessment)
+        except Exception:
+            logger.warning("ProductAnalyzer JSON 파싱 실패 — 기본값 반환")
+            return AnalysisResult(
+                preference_fit_score=DEFAULT_SCORE,
+                assessment=DEFAULT_ASSESSMENT,
+            )

--- a/shopigent/llm/prompts/analyzer_prompts.py
+++ b/shopigent/llm/prompts/analyzer_prompts.py
@@ -1,0 +1,26 @@
+from shopigent.scraper.base import RawProduct
+
+PRODUCT_ANALYZER_SYSTEM_PROMPT = (
+    "당신은 쇼핑 상품 분석 전문가입니다.\n"
+    "사용자 취향과 상품 정보를 비교하여 취향 적합도를 JSON으로 반환하세요.\n"
+    '반드시 다음 형식의 JSON만 출력하세요: '
+    '{"preference_fit_score": 0-200, "assessment": "평가 텍스트"}\n'
+    "preference_fit_score는 0(완전 불일치)~200(완벽 일치) 범위의 정수입니다.\n"
+    "assessment는 한국어로 2~3문장 이내로 작성하세요."
+)
+
+
+def format_product_analyzer_user_prompt(product: RawProduct, user_preference_text: str) -> str:
+    price_str = f"{product.price:,}원" if product.price is not None else "가격 미상"
+    return (
+        f"[상품 정보]\n"
+        f"- 상품명: {product.title}\n"
+        f"- 가격: {price_str}\n"
+        f"- 배송비: {product.delivery_fee:,}원\n"
+        f"- 브랜드: {product.brand or '미상'}\n"
+        f"- 카테고리: {product.category or '미상'}\n"
+        f"- 설명: {product.description or '없음'}\n"
+        f"- 리뷰 수: {product.review_count}\n"
+        f"- 평균 평점: {product.review_avg_rating or '없음'}\n\n"
+        f"[사용자 취향]\n{user_preference_text}"
+    )

--- a/shopigent/llm/router.py
+++ b/shopigent/llm/router.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+import httpx
+
+from shopigent.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class LLMTaskType(Enum):
+    QUERY_EXPAND = "query_expand"
+    PRODUCT_ANALYZE = "product_analyze"
+    REPORT_GENERATE = "report_generate"
+    DOM_PARSE = "dom_parse"
+
+
+@dataclass(frozen=True)
+class ModelConfig:
+    primary_model: str
+    fallback_model: str
+    timeout_sec: int = 30
+
+
+_DEFAULT_ROUTING: dict[LLMTaskType, ModelConfig] = {
+    LLMTaskType.QUERY_EXPAND: ModelConfig(
+        primary_model="ollama/qwen2.5:7b",
+        fallback_model="gemini/gemini-2.0-flash",
+        timeout_sec=15,
+    ),
+    LLMTaskType.PRODUCT_ANALYZE: ModelConfig(
+        primary_model="ollama/qwen2.5:7b",
+        fallback_model="gemini/gemini-2.0-flash",
+        timeout_sec=30,
+    ),
+    LLMTaskType.REPORT_GENERATE: ModelConfig(
+        primary_model="gemini/gemini-2.0-flash",
+        fallback_model="gpt-4o-mini",
+        timeout_sec=60,
+    ),
+    LLMTaskType.DOM_PARSE: ModelConfig(
+        primary_model="gemini/gemini-2.0-flash",
+        fallback_model="gpt-4o-mini",
+        timeout_sec=30,
+    ),
+}
+
+
+class LLMRouter:
+    def __init__(
+        self,
+        routing_table: dict[LLMTaskType, ModelConfig] | None = None,
+    ):
+        self._routing = routing_table or _DEFAULT_ROUTING
+        self._ollama_base_url = settings.ollama_base_url
+
+    def get_model(self, task_type: LLMTaskType) -> str:
+        config = self._routing[task_type]
+        if config.primary_model.startswith("ollama/"):
+            if self._is_ollama_available():
+                return config.primary_model
+            logger.info(
+                "Ollama unavailable for %s, falling back to %s",
+                task_type.value,
+                config.fallback_model,
+            )
+            return config.fallback_model
+        return config.primary_model
+
+    def get_config(self, task_type: LLMTaskType) -> ModelConfig:
+        return self._routing[task_type]
+
+    def _is_ollama_available(self) -> bool:
+        try:
+            resp = httpx.get(self._ollama_base_url, timeout=2)
+            return resp.status_code == 200
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return False

--- a/shopigent/llm/token_counter.py
+++ b/shopigent/llm/token_counter.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+import litellm
+
+
+@dataclass
+class TokenCount:
+    input_tokens: int
+    output_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.output_tokens
+
+
+DEFAULT_MODEL = "gpt-3.5-turbo"
+
+
+class TokenCounter:
+    def __init__(self, model: str = DEFAULT_MODEL):
+        self.model = model
+
+    def count_messages(self, messages: list[dict]) -> TokenCount:
+        input_tokens = litellm.token_counter(model=self.model, messages=messages)
+        return TokenCount(input_tokens=input_tokens)

--- a/tests/unit/test_llm_analyzer.py
+++ b/tests/unit/test_llm_analyzer.py
@@ -1,0 +1,118 @@
+"""ProductAnalyzer 단위 테스트 — LLM 취향 분석 및 JSON 출력 검증"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shopigent.llm.analyzer import AnalysisResult, ProductAnalyzer
+from shopigent.scraper.base import RawProduct
+
+
+@pytest.fixture
+def mock_llm_provider():
+    provider = MagicMock()
+    provider.complete_json = AsyncMock()
+    return provider
+
+
+@pytest.fixture
+def sample_product():
+    return RawProduct(
+        url="https://example.com/product/1",
+        title="노스페이스 눕시 패딩 700 다운",
+        shop_domain="example.com",
+        price=350000,
+        delivery_fee=0,
+        brand="노스페이스",
+        description="700 필파워 구스다운, 방풍 기능, 겨울 아우터",
+        review_count=1200,
+        review_avg_rating=4.7,
+    )
+
+
+@pytest.fixture
+def user_preference_text():
+    return (
+        "겨울 패딩을 찾고 있습니다. "
+        "따뜻하고 가벼운 다운 패딩 선호, 브랜드는 노스페이스나 파타고니아"
+    )
+
+
+@pytest.mark.asyncio
+async def test_analyze_returns_analysis_result(
+    mock_llm_provider, sample_product, user_preference_text
+):
+    """AnalysisResult 타입 반환 확인"""
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 180,
+        "assessment": "노스페이스 눕시 패딩은 사용자가 선호하는 브랜드이며 따뜻한 다운 패딩입니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert isinstance(result, AnalysisResult)
+    assert isinstance(result.preference_fit_score, float)
+    assert isinstance(result.assessment, str)
+
+
+@pytest.mark.asyncio
+async def test_score_in_valid_range(mock_llm_provider, sample_product, user_preference_text):
+    """점수가 0~200 범위인지 확인"""
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 150,
+        "assessment": "적합한 상품입니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert 0 <= result.preference_fit_score <= 200
+
+
+@pytest.mark.asyncio
+async def test_json_parse_failure_returns_default(
+    mock_llm_provider, sample_product, user_preference_text
+):
+    """LLM이 invalid JSON 반환 시 기본값"""
+    mock_llm_provider.complete_json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert result.preference_fit_score == 100.0
+    assert result.assessment == "분석 실패"
+
+
+@pytest.mark.asyncio
+async def test_high_fit_product_gets_high_score(
+    mock_llm_provider, sample_product, user_preference_text
+):
+    """취향 일치 상품 → 높은 점수 (mock)"""
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 190,
+        "assessment": "브랜드, 기능, 스타일 모두 취향과 일치합니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert result.preference_fit_score >= 150
+
+
+@pytest.mark.asyncio
+async def test_low_fit_product_gets_low_score(mock_llm_provider, user_preference_text):
+    """취향 불일치 상품 → 낮은 점수 (mock)"""
+    low_fit_product = RawProduct(
+        url="https://example.com/product/2",
+        title="여름용 린넨 셔츠",
+        shop_domain="example.com",
+        price=45000,
+        brand="유니클로",
+        description="여름 시즌 린넨 소재 셔츠, 시원한 착용감",
+    )
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 20,
+        "assessment": "겨울 패딩을 찾는 사용자에게 여름 셔츠는 부적합합니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(low_fit_product, user_preference_text)
+
+    assert result.preference_fit_score <= 50

--- a/tests/unit/test_llm_router.py
+++ b/tests/unit/test_llm_router.py
@@ -1,0 +1,45 @@
+"""LLMRouter 단위 테스트 — 태스크별 모델 라우팅."""
+
+from unittest.mock import patch
+
+from shopigent.llm.router import LLMRouter, LLMTaskType
+
+
+class TestLLMRouter:
+    """LLMRouter 라우팅 로직 검증."""
+
+    def setup_method(self):
+        self.router = LLMRouter()
+
+
+    @patch.object(LLMRouter, "_is_ollama_available", return_value=True)
+    def test_product_analyze_uses_ollama_when_available(self, mock_ollama):
+        model = self.router.get_model(LLMTaskType.PRODUCT_ANALYZE)
+        assert "ollama" in model
+
+
+    @patch.object(LLMRouter, "_is_ollama_available", return_value=False)
+    def test_product_analyze_fallback_when_ollama_unavailable(self, mock_ollama):
+        model = self.router.get_model(LLMTaskType.PRODUCT_ANALYZE)
+        assert "ollama" not in model
+        assert "gemini" in model
+
+
+    @patch.object(LLMRouter, "_is_ollama_available", return_value=True)
+    def test_report_generate_uses_cloud_model(self, mock_ollama):
+        model = self.router.get_model(LLMTaskType.REPORT_GENERATE)
+        assert "ollama" not in model
+
+
+    @patch.object(LLMRouter, "_is_ollama_available", return_value=True)
+    def test_all_task_types_have_routing(self, mock_ollama):
+        for task_type in LLMTaskType:
+            model = self.router.get_model(task_type)
+            assert model, f"{task_type.name}에 라우팅이 없습니다"
+
+
+    @patch.object(LLMRouter, "_is_ollama_available", return_value=True)
+    def test_get_model_returns_string(self, mock_ollama):
+        for task_type in LLMTaskType:
+            model = self.router.get_model(task_type)
+            assert isinstance(model, str)

--- a/tests/unit/test_token_counting.py
+++ b/tests/unit/test_token_counting.py
@@ -1,0 +1,172 @@
+from shopigent.llm.token_counter import TokenCount, TokenCounter
+
+SAMPLE_PRODUCT = {
+    "title": "노스페이스 눕시 다운 패딩 점퍼 남성 겨울 구스다운 NJ1DQ55A",
+    "brand": "노스페이스",
+    "price": 289000,
+    "delivery_fee": 0,
+    "category": "패딩/점퍼",
+    "review_count": 1842,
+    "review_avg_rating": 4.7,
+    "description": "구스다운 90% 충전재 사용. 방풍/방수 기능성 원단. 경량 압축 보관 가능.",
+    "specs": {"소재": "겉감 100% 나일론, 충전재 구스다운 90%", "색상": "블랙, 네이비"},
+}
+
+SAMPLE_USER_PREFERENCE = "선호 브랜드: 노스페이스. 예산: 20~40만원. 선호 기능: 방풍, 방수."
+
+
+def _build_query_expander_messages(query: str) -> list[dict]:
+    """검색어 확장 프롬프트를 구성합니다."""
+    return [
+        {
+            "role": "system",
+            "content": (
+                "당신은 쇼핑 검색 전문가입니다. "
+                "사용자의 검색어를 분석하여 관련 키워드를 확장해주세요. "
+                "결과는 JSON 배열로 반환하세요."
+            ),
+        },
+        {
+            "role": "user",
+            "content": f"검색어: {query}\n\n관련 키워드 5개를 생성해주세요.",
+        },
+    ]
+
+
+def _build_product_analyzer_messages(
+    product: dict,
+    user_preference: str,
+) -> list[dict]:
+    """상품 분석 프롬프트를 구성합니다."""
+    product_info = (
+        f"상품명: {product['title']}\n"
+        f"브랜드: {product['brand']}\n"
+        f"가격: {product['price']:,}원\n"
+        f"배송비: {product['delivery_fee']:,}원\n"
+        f"카테고리: {product['category']}\n"
+        f"리뷰 수: {product['review_count']:,}건\n"
+        f"평균 평점: {product['review_avg_rating']}\n"
+        f"설명: {product['description']}\n"
+        f"스펙: {product['specs']}\n"
+    )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "당신은 상품 품질 분석 전문가입니다. "
+                "상품 정보와 사용자 선호도를 비교하여 적합도를 0~200점으로 평가해주세요. "
+                "JSON으로 {score, reason} 형태로 반환하세요."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"## 사용자 선호도\n{user_preference}\n\n"
+                f"## 상품 정보\n{product_info}\n"
+                "위 상품의 취향 적합도를 평가해주세요."
+            ),
+        },
+    ]
+
+
+def _build_report_generator_messages(
+    top5_products: list[dict],
+    query: str,
+) -> list[dict]:
+    """Top5 리포트 생성 프롬프트를 구성합니다."""
+    products_text = ""
+    for i, p in enumerate(top5_products, 1):
+        products_text += (
+            f"\n### {i}위: {p['title']}\n"
+            f"- 가격: {p['price']:,}원\n"
+            f"- 브랜드: {p['brand']}\n"
+            f"- 평점: {p['review_avg_rating']} ({p['review_count']:,}건)\n"
+            f"- 설명: {p['description']}\n"
+        )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "당신은 쇼핑 리포트 작성 전문가입니다. "
+                "Top 5 상품 분석 결과를 보기 좋은 HTML 리포트로 작성해주세요. "
+                "각 상품의 장단점, 추천 이유를 포함하세요."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"검색어: {query}\n\n"
+                f"## Top 5 상품 분석 결과\n{products_text}\n"
+                "위 상품들에 대한 상세 리포트를 HTML 형식으로 작성해주세요."
+            ),
+        },
+    ]
+
+class TestTokenCounting:
+    """호출 지점별 토큰 수 측정 테스트."""
+
+    def setup_method(self):
+        self.counter = TokenCounter()
+
+    def test_count_query_expander_tokens(self):
+        """검색어 확장 프롬프트의 토큰 수를 측정한다."""
+        messages = _build_query_expander_messages("겨울 패딩")
+        result = self.counter.count_messages(messages)
+
+        assert isinstance(result, TokenCount)
+        assert result.input_tokens > 0
+        # 검색어 확장 프롬프트는 비교적 짧음 (100~500 토큰 예상)
+        assert result.input_tokens < 5000
+        print(f"\n[QueryExpander] input_tokens={result.input_tokens}")
+
+    def test_count_product_analyzer_tokens(self):
+        """상품 1건 분석 프롬프트의 토큰 수를 측정한다."""
+        messages = _build_product_analyzer_messages(
+            SAMPLE_PRODUCT,
+            SAMPLE_USER_PREFERENCE,
+        )
+        result = self.counter.count_messages(messages)
+
+        assert isinstance(result, TokenCount)
+        assert result.input_tokens > 0
+        # 상품 분석은 중간 길이 (200~1000 토큰 예상)
+        assert result.input_tokens < 10000
+        print(f"\n[ProductAnalyzer] input_tokens={result.input_tokens}")
+
+    def test_count_report_generator_tokens(self):
+        """Top5 리포트 생성 프롬프트의 토큰 수를 측정한다."""
+        top5 = [SAMPLE_PRODUCT] * 5  # 동일 상품 5개로 시뮬레이션
+        messages = _build_report_generator_messages(top5, "겨울 패딩")
+        result = self.counter.count_messages(messages)
+
+        assert isinstance(result, TokenCount)
+        assert result.input_tokens > 0
+        # 리포트 생성은 가장 긴 프롬프트 (500~3000 토큰 예상)
+        assert result.input_tokens < 20000
+        print(f"\n[ReportGenerator] input_tokens={result.input_tokens}")
+
+    def test_token_count_is_positive(self):
+        """어떤 메시지든 토큰 수는 0보다 크다."""
+        messages = [{"role": "user", "content": "hello"}]
+        result = self.counter.count_messages(messages)
+
+        assert result.input_tokens > 0
+        assert result.total_tokens > 0
+
+    def test_token_count_dataclass_fields(self):
+        """TokenCount는 input_tokens, output_tokens, total_tokens 필드를 갖는다."""
+        messages = [{"role": "user", "content": "test"}]
+        result = self.counter.count_messages(messages)
+
+        assert hasattr(result, "input_tokens")
+        assert hasattr(result, "output_tokens")
+        assert hasattr(result, "total_tokens")
+        assert result.total_tokens == result.input_tokens + result.output_tokens
+
+    def test_custom_model_name(self):
+        """모델명을 지정하면 해당 모델 기준으로 토큰을 카운팅한다."""
+        counter = TokenCounter(model="gpt-4")
+        messages = [{"role": "user", "content": "hello world"}]
+        result = counter.count_messages(messages)
+
+        assert result.input_tokens > 0


### PR DESCRIPTION
## Summary
- `LLMRouter` 클래스 구현: 태스크 유형별(QUERY_EXPAND, PRODUCT_ANALYZE, REPORT_GENERATE, DOM_PARSE) 최적 모델 자동 선택
- Ollama 가용 여부 자동 감지 → 불가 시 클라우드 모델(Gemini/GPT-4o-mini) 폴백
- `config.py`에 `llm_analyzer_model`, `llm_report_model`, `llm_query_model`, `ollama_base_url` 설정 추가

## Test Results
- 5개 단위 테스트 전부 통과 (TDD Red→Green)
- `make lint` 변경 파일 기준 clean

Closes #3