### PR TITLE
[#2] ProductAnalyzer + Ollama 연동

### DIFF
--- a/shopigent/llm/analyzer.py
+++ b/shopigent/llm/analyzer.py
@@ -1,0 +1,48 @@
+import logging
+from dataclasses import dataclass
+
+from shopigent.llm.prompts.analyzer_prompts import (
+    PRODUCT_ANALYZER_SYSTEM_PROMPT,
+    format_product_analyzer_user_prompt,
+)
+from shopigent.llm.provider import LLMProvider
+from shopigent.scraper.base import RawProduct
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SCORE = 100.0
+DEFAULT_ASSESSMENT = "분석 실패"
+SCORE_MIN = 0.0
+SCORE_MAX = 200.0
+
+
+@dataclass
+class AnalysisResult:
+    preference_fit_score: float
+    assessment: str
+
+
+class ProductAnalyzer:
+    def __init__(self, llm_provider: LLMProvider):
+        self._llm = llm_provider
+
+    async def analyze(self, product: RawProduct, user_preference_text: str) -> AnalysisResult:
+        messages = [
+            {"role": "system", "content": PRODUCT_ANALYZER_SYSTEM_PROMPT},
+            {
+                "role": "user",
+                "content": format_product_analyzer_user_prompt(product, user_preference_text),
+            },
+        ]
+        try:
+            data = await self._llm.complete_json(messages=messages)
+            score = float(data.get("preference_fit_score", DEFAULT_SCORE))
+            score = max(SCORE_MIN, min(SCORE_MAX, score))
+            assessment = str(data.get("assessment", DEFAULT_ASSESSMENT))
+            return AnalysisResult(preference_fit_score=score, assessment=assessment)
+        except Exception:
+            logger.warning("ProductAnalyzer JSON 파싱 실패 — 기본값 반환")
+            return AnalysisResult(
+                preference_fit_score=DEFAULT_SCORE,
+                assessment=DEFAULT_ASSESSMENT,
+            )

--- a/shopigent/llm/prompts/analyzer_prompts.py
+++ b/shopigent/llm/prompts/analyzer_prompts.py
@@ -1,0 +1,26 @@
+from shopigent.scraper.base import RawProduct
+
+PRODUCT_ANALYZER_SYSTEM_PROMPT = (
+    "당신은 쇼핑 상품 분석 전문가입니다.\n"
+    "사용자 취향과 상품 정보를 비교하여 취향 적합도를 JSON으로 반환하세요.\n"
+    "반드시 다음 형식의 JSON만 출력하세요: "
+    '{"preference_fit_score": 0-200, "assessment": "평가 텍스트"}\n'
+    "preference_fit_score는 0(완전 불일치)~200(완벽 일치) 범위의 정수입니다.\n"
+    "assessment는 한국어로 2~3문장 이내로 작성하세요."
+)
+
+
+def format_product_analyzer_user_prompt(product: RawProduct, user_preference_text: str) -> str:
+    price_str = f"{product.price:,}원" if product.price is not None else "가격 미상"
+    return (
+        f"[상품 정보]\n"
+        f"- 상품명: {product.title}\n"
+        f"- 가격: {price_str}\n"
+        f"- 배송비: {product.delivery_fee:,}원\n"
+        f"- 브랜드: {product.brand or '미상'}\n"
+        f"- 카테고리: {product.category or '미상'}\n"
+        f"- 설명: {product.description or '없음'}\n"
+        f"- 리뷰 수: {product.review_count}\n"
+        f"- 평균 평점: {product.review_avg_rating or '없음'}\n\n"
+        f"[사용자 취향]\n{user_preference_text}"
+    )

--- a/tests/unit/test_llm_analyzer.py
+++ b/tests/unit/test_llm_analyzer.py
@@ -1,0 +1,118 @@
+"""ProductAnalyzer 단위 테스트 — LLM 취향 분석 및 JSON 출력 검증"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from shopigent.llm.analyzer import AnalysisResult, ProductAnalyzer
+from shopigent.scraper.base import RawProduct
+
+
+@pytest.fixture
+def mock_llm_provider():
+    provider = MagicMock()
+    provider.complete_json = AsyncMock()
+    return provider
+
+
+@pytest.fixture
+def sample_product():
+    return RawProduct(
+        url="https://example.com/product/1",
+        title="노스페이스 눕시 패딩 700 다운",
+        shop_domain="example.com",
+        price=350000,
+        delivery_fee=0,
+        brand="노스페이스",
+        description="700 필파워 구스다운, 방풍 기능, 겨울 아우터",
+        review_count=1200,
+        review_avg_rating=4.7,
+    )
+
+
+@pytest.fixture
+def user_preference_text():
+    return (
+        "겨울 패딩을 찾고 있습니다. "
+        "따뜻하고 가벼운 다운 패딩 선호, 브랜드는 노스페이스나 파타고니아"
+    )
+
+
+@pytest.mark.asyncio
+async def test_analyze_returns_analysis_result(
+    mock_llm_provider, sample_product, user_preference_text
+):
+    """AnalysisResult 타입 반환 확인"""
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 180,
+        "assessment": "노스페이스 눕시 패딩은 사용자가 선호하는 브랜드이며 따뜻한 다운 패딩입니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert isinstance(result, AnalysisResult)
+    assert isinstance(result.preference_fit_score, float)
+    assert isinstance(result.assessment, str)
+
+
+@pytest.mark.asyncio
+async def test_score_in_valid_range(mock_llm_provider, sample_product, user_preference_text):
+    """점수가 0~200 범위인지 확인"""
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 150,
+        "assessment": "적합한 상품입니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert 0 <= result.preference_fit_score <= 200
+
+
+@pytest.mark.asyncio
+async def test_json_parse_failure_returns_default(
+    mock_llm_provider, sample_product, user_preference_text
+):
+    """LLM이 invalid JSON 반환 시 기본값"""
+    mock_llm_provider.complete_json.side_effect = json.JSONDecodeError("Expecting value", "", 0)
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert result.preference_fit_score == 100.0
+    assert result.assessment == "분석 실패"
+
+
+@pytest.mark.asyncio
+async def test_high_fit_product_gets_high_score(
+    mock_llm_provider, sample_product, user_preference_text
+):
+    """취향 일치 상품 → 높은 점수 (mock)"""
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 190,
+        "assessment": "브랜드, 기능, 스타일 모두 취향과 일치합니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(sample_product, user_preference_text)
+
+    assert result.preference_fit_score >= 150
+
+
+@pytest.mark.asyncio
+async def test_low_fit_product_gets_low_score(mock_llm_provider, user_preference_text):
+    """취향 불일치 상품 → 낮은 점수 (mock)"""
+    low_fit_product = RawProduct(
+        url="https://example.com/product/2",
+        title="여름용 린넨 셔츠",
+        shop_domain="example.com",
+        price=45000,
+        brand="유니클로",
+        description="여름 시즌 린넨 소재 셔츠, 시원한 착용감",
+    )
+    mock_llm_provider.complete_json.return_value = {
+        "preference_fit_score": 20,
+        "assessment": "겨울 패딩을 찾는 사용자에게 여름 셔츠는 부적합합니다.",
+    }
+    analyzer = ProductAnalyzer(llm_provider=mock_llm_provider)
+    result = await analyzer.analyze(low_fit_product, user_preference_text)
+
+    assert result.preference_fit_score <= 50


### PR DESCRIPTION
## Summary
- `ProductAnalyzer` 클래스 구현 (`shopigent/llm/analyzer.py`): LLM을 통한 상품-취향 적합도 분석, 0~200점 스코어링, JSON 파싱 실패 시 기본값 반환
- 프롬프트 분리 (`shopigent/llm/prompts/analyzer_prompts.py`): 시스템/유저 프롬프트 상수 및 포맷 함수
- 단위 테스트 5개 (`tests/unit/test_llm_analyzer.py`): AsyncMock 기반, 타입/범위/에러핸들링/고점수/저점수 검증

Closes #2